### PR TITLE
Use latest version of gcr image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/go-containerregistry/github.com/google/go-containerregistry/cmd/crane@sha256:b96a3947b5b18ac518239ccef3370315d2f5fdc8ccede383a1ea2fbcaec621b7
+FROM gcr.io/go-containerregistry/github.com/google/go-containerregistry/cmd/crane@sha256:2ebe1fffc23ac887cde2718b46f6133511b089e358bc08baa4de465675a1188f
 
 FROM busybox@sha256:fe301db49df08c384001ed752dff6d52b4305a73a7f608f21528048e8a08b51e
 


### PR DESCRIPTION
The latest image as a way better docker_config.json handling.
It makes it work with gitlab-ci.